### PR TITLE
Make drift command read-only

### DIFF
--- a/src/dss_provisioner/config/__init__.py
+++ b/src/dss_provisioner/config/__init__.py
@@ -80,7 +80,7 @@ def plan_and_apply(config: Config, *, destroy: bool = False, refresh: bool = Tru
 def refresh(config: Config) -> State:
     """Refresh state from the live DSS instance."""
     engine = _engine_from_config(config)
-    return engine.refresh()
+    return engine.refresh(persist=True)
 
 
 def drift(config: Config) -> list[ResourceChange]:

--- a/src/dss_provisioner/engine/engine.py
+++ b/src/dss_provisioner/engine/engine.py
@@ -143,11 +143,11 @@ class DSSEngine:
 
         return changed
 
-    def refresh(self) -> State:
+    def refresh(self, *, persist: bool = False) -> State:
         with StateLock(self._state_path):
             state = self._load_state()
             changed = self._refresh_state_in_place(state)
-            if changed:
+            if changed and persist:
                 state.serial += 1
                 state.save(self._state_path)
             return state


### PR DESCRIPTION
## Summary

- Add `persist` keyword-only parameter to `engine.refresh()`, defaulting to `False` (safe by default)
- `config.refresh()` opts in with `persist=True`; `config.drift()` uses the default — no disk writes
- New test verifies no-persist behavior (in-memory state reflects drift, on-disk state unchanged)

Closes #21

## Test plan

- [x] Existing `test_refresh_updates_state_and_writes_backup` passes with explicit `persist=True`
- [x] New `test_refresh_no_persist_does_not_write` verifies serial not bumped and on-disk state unchanged
- [x] `just format && just check && just test` — 271 tests pass, 90% coverage