### PR TITLE
Add confirmation prompt to refresh command

### DIFF
--- a/src/dss_provisioner/cli/commands.py
+++ b/src/dss_provisioner/cli/commands.py
@@ -242,7 +242,7 @@ def refresh_cmd(
 
     typer.echo(format_changes(changes, color=color))
     typer.echo()
-    typer.echo(format_plan_summary(changes_summary(changes), color=color))
+    typer.echo(format_plan_summary(changes_summary(changes), color=color, header="Refresh"))
     typer.echo()
 
     if not auto_approve:

--- a/src/dss_provisioner/cli/formatting.py
+++ b/src/dss_provisioner/cli/formatting.py
@@ -149,9 +149,11 @@ def changes_summary(changes: list[ResourceChange]) -> dict[str, int]:
     return summary
 
 
-def format_plan_summary(summary: dict[str, int], *, color: bool = True) -> str:
+def format_plan_summary(
+    summary: dict[str, int], *, color: bool = True, header: str = "Plan"
+) -> str:
     """Render ``Plan: 2 to add, 1 to change, 0 to destroy.``"""
-    return f"Plan: {_format_summary(summary, _PLAN_VERBS, color=color)}."
+    return f"{header}: {_format_summary(summary, _PLAN_VERBS, color=color)}."
 
 
 def format_apply_summary(summary: dict[str, int], *, color: bool = True) -> str:

--- a/src/dss_provisioner/config/__init__.py
+++ b/src/dss_provisioner/config/__init__.py
@@ -79,7 +79,7 @@ def plan_and_apply(config: Config, *, destroy: bool = False, refresh: bool = Tru
 
 
 def refresh(config: Config) -> tuple[list[ResourceChange], State]:
-    """Refresh state from DSS (single API call, not persisted).
+    """Refresh state from the live DSS instance (not persisted).
 
     Returns the list of drift changes and the new state. Call
     :func:`save_state` to persist the returned state to disk.

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -282,6 +282,7 @@ class TestRefreshCommand:
 
         result = runner.invoke(app, ["refresh", "--no-color", "--auto-approve"])
         assert "dss_dataset.raw" in result.stdout
+        assert "Refresh: " in result.stdout
         assert "1 to change" in result.stdout
 
 


### PR DESCRIPTION
## Summary
- `refresh` now shows drift changes and prompts for confirmation before writing state, matching the UX of `apply` and `destroy`
- Adds `--auto-approve` flag to skip the prompt for CI/scripting
- Refactors `config.refresh()` to return `(changes, state)` without persisting; new `config.save_state()` handles persistence separately
- Simplifies `config.drift()` to a thin wrapper over `refresh()`
- Extracts `format_changes()` and `changes_summary()` helpers in formatting, deduplicating rendering logic across `refresh`, `drift`, and `plan` commands

## Test plan
- [x] Unit tests: 4 new tests covering no-changes, auto-approve, user-decline, and drift-display scenarios
- [x] `just format && just check && just test` — 273 tests pass, 90% coverage
- [x] E2e verified against local DSS Free Edition: no-drift, decline, auto-approve, idempotent re-run

Closes #31