### PR TITLE
Fix drift() double state load (TOCTOU)

### DIFF
--- a/src/dss_provisioner/config/__init__.py
+++ b/src/dss_provisioner/config/__init__.py
@@ -85,8 +85,7 @@ def refresh(config: Config) -> tuple[list[ResourceChange], State]:
     :func:`save_state` to persist the returned state to disk.
     """
     engine = _engine_from_config(config)
-    old_state = State.load_or_create(config.state_path, config.provider.project)
-    new_state = engine.refresh()
+    old_state, new_state = engine.refresh()
     return _build_drift_changes(old_state, new_state), new_state
 
 

--- a/src/dss_provisioner/engine/engine.py
+++ b/src/dss_provisioner/engine/engine.py
@@ -143,14 +143,16 @@ class DSSEngine:
 
         return changed
 
-    def refresh(self, *, persist: bool = False) -> State:
+    def refresh(self, *, persist: bool = False) -> tuple[State, State]:
+        """Refresh state from DSS. Returns (pre_refresh, post_refresh)."""
         with StateLock(self._state_path):
             state = self._load_state()
+            snapshot = state.model_copy(deep=True)
             changed = self._refresh_state_in_place(state)
             if changed and persist:
                 state.serial += 1
                 state.save(self._state_path)
-            return state
+            return snapshot, state
 
     @staticmethod
     def _resolve_deps(desired_by_addr: dict[str, Resource]) -> dict[str, list[str]]:

--- a/tests/unit/test_engine_refresh.py
+++ b/tests/unit/test_engine_refresh.py
@@ -80,8 +80,9 @@ def test_refresh_updates_state_and_writes_backup(tmp_path: Path) -> None:
 
     # Simulate drift
     handler.store["dummy.r1"]["value"] = 99
-    state = engine.refresh(persist=True)
+    snapshot, state = engine.refresh(persist=True)
 
+    assert snapshot.resources["dummy.r1"].attributes["value"] == 1
     assert state.serial == 2
     assert state.resources["dummy.r1"].attributes["value"] == 99
 
@@ -90,8 +91,9 @@ def test_refresh_updates_state_and_writes_backup(tmp_path: Path) -> None:
 
     # Simulate deletion out-of-band
     handler.store.pop("dummy.r1")
-    state2 = engine.refresh(persist=True)
+    snapshot2, state2 = engine.refresh(persist=True)
 
+    assert "dummy.r1" in snapshot2.resources
     assert state2.serial == 3
     assert state2.resources == {}
 
@@ -102,7 +104,10 @@ def test_refresh_no_persist_does_not_write(tmp_path: Path) -> None:
     engine.apply(engine.plan([r1]))
 
     handler.store["dummy.r1"]["value"] = 99
-    state = engine.refresh()  # default: persist=False
+    snapshot, state = engine.refresh()  # default: persist=False
+
+    # Snapshot preserves pre-refresh attributes
+    assert snapshot.resources["dummy.r1"].attributes["value"] == 1
 
     # In-memory state reflects drift
     assert state.resources["dummy.r1"].attributes["value"] == 99


### PR DESCRIPTION
## Summary

- `engine.refresh()` now returns `tuple[State, State]` — a deep-copied snapshot before mutation and the mutated state after, eliminating the TOCTOU window where `config.refresh()` loaded state twice (once outside the lock, once inside)
- `config.refresh()` no longer calls `State.load_or_create` separately — single load, single lock, no race
- Added snapshot assertions in tests to verify the deep-copy preserves pre-refresh state

Closes #30

## Test plan

- [x] `just format` — no changes
- [x] `just check` — all checks passed
- [x] `just test` — 273 tests pass, 90% coverage