### PR TITLE
Validate unique resource names across config

### DIFF
--- a/src/dss_provisioner/resources/base.py
+++ b/src/dss_provisioner/resources/base.py
@@ -17,6 +17,7 @@ class Resource(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     resource_type: ClassVar[str]
+    namespace: ClassVar[str]
     plan_priority: ClassVar[int] = 100
 
     name: str = Field(pattern=r"^[a-zA-Z0-9_]+$")

--- a/src/dss_provisioner/resources/code_env.py
+++ b/src/dss_provisioner/resources/code_env.py
@@ -16,6 +16,7 @@ class CodeEnvResource(Resource):
     """
 
     resource_type: ClassVar[str] = "dss_code_env"
+    namespace: ClassVar[str] = "code_env"
     plan_priority: ClassVar[int] = 5
 
     name: Literal["code_envs"] = "code_envs"

--- a/src/dss_provisioner/resources/dataset.py
+++ b/src/dss_provisioner/resources/dataset.py
@@ -34,6 +34,7 @@ class DatasetResource(Resource):
     """Base resource for DSS datasets."""
 
     resource_type: ClassVar[str] = "dss_dataset"
+    namespace: ClassVar[str] = "dataset"
     sql_types: ClassVar[set[str]] = {"PostgreSQL", "Snowflake", "Oracle", "MySQL"}
 
     type: str

--- a/src/dss_provisioner/resources/git_library.py
+++ b/src/dss_provisioner/resources/git_library.py
@@ -17,6 +17,7 @@ class GitLibraryResource(Resource):
     """
 
     resource_type: ClassVar[str] = "dss_git_library"
+    namespace: ClassVar[str] = "library"
     plan_priority: ClassVar[int] = 10
 
     repository: str = Field(min_length=1)

--- a/src/dss_provisioner/resources/managed_folder.py
+++ b/src/dss_provisioner/resources/managed_folder.py
@@ -14,6 +14,7 @@ class ManagedFolderResource(Resource):
     """Base resource for DSS managed folders."""
 
     resource_type: ClassVar[str] = "dss_managed_folder"
+    namespace: ClassVar[str] = "managed_folder"
 
     type: str
     connection: Annotated[str | None, DSSParam("params.connection")] = None

--- a/src/dss_provisioner/resources/recipe.py
+++ b/src/dss_provisioner/resources/recipe.py
@@ -25,6 +25,7 @@ class RecipeResource(Resource):
     """Base resource for DSS recipes."""
 
     resource_type: ClassVar[str] = "dss_recipe"
+    namespace: ClassVar[str] = "recipe"
 
     type: str
     inputs: Annotated[StrOrList, Ref()] = Field(default_factory=list)

--- a/src/dss_provisioner/resources/scenario.py
+++ b/src/dss_provisioner/resources/scenario.py
@@ -13,6 +13,7 @@ class ScenarioResource(Resource):
     """Base resource for DSS scenarios."""
 
     resource_type: ClassVar[str] = "dss_scenario"
+    namespace: ClassVar[str] = "scenario"
     plan_priority: ClassVar[int] = 200
 
     type: str

--- a/src/dss_provisioner/resources/variables.py
+++ b/src/dss_provisioner/resources/variables.py
@@ -19,6 +19,7 @@ class VariablesResource(Resource):
     """
 
     resource_type: ClassVar[str] = "dss_variables"
+    namespace: ClassVar[str] = "variables"
     plan_priority: ClassVar[int] = 0
 
     name: Literal["variables"] = "variables"

--- a/src/dss_provisioner/resources/zone.py
+++ b/src/dss_provisioner/resources/zone.py
@@ -17,4 +17,5 @@ class ZoneResource(Resource):
     """
 
     resource_type: ClassVar[str] = "dss_zone"
+    namespace: ClassVar[str] = "zone"
     color: str = Field(default="#2ab1ac", pattern=r"^#[0-9A-Fa-f]{6}$")


### PR DESCRIPTION
## Summary

- Adds `namespace` ClassVar to `Resource` base class, set on each base resource class (dataset, recipe, scenario, managed_folder, zone, library, variables, code_env)
- Validates name uniqueness per namespace at config-load time via `_validate_unique_names()`, catching cross-subtype duplicates (e.g. Snowflake + Filesystem dataset both named "raw")
- Raises `ConfigError` before any DSS connection is made, including duplicates introduced by module expansion

## Test plan

- [x] Unit tests for `_validate_unique_names` (same subtype, cross-subtype, different namespace, no duplicates)
- [x] Integration tests via `load_config` (YAML duplicates, module collision with top-level)
- [x] All 559 existing tests pass
- [x] `just format && just check && just test` clean

Closes #56