### PR TITLE
Replace pydantic-settings with manual env resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.10",
-    "pydantic-settings>=2.7",
+    "python-dotenv>=1.0",
     "dataiku-api-client>=14.0",
     "ruamel-yaml>=0.18",
     "typer>=0.9",

--- a/src/dss_provisioner/config/schema.py
+++ b/src/dss_provisioner/config/schema.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Discriminator, PrivateAttr, computed_field
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from dss_provisioner.config.modules import (
     ModuleSpec,  # noqa: TC001 — Pydantic needs this at runtime
@@ -57,19 +56,17 @@ from dss_provisioner.resources.zone import (
 )
 
 
-class ProviderConfig(BaseSettings):
+class ProviderConfig(BaseModel):
     """DSS provider connection settings.
 
-    Fields can be set via YAML (constructor kwargs), environment variables
-    with the ``DSS_`` prefix, or a ``.env`` file next to the config file.
+    Fields can be set via YAML, environment variables (``DSS_HOST``,
+    ``DSS_API_KEY``, ``DSS_PROJECT``), or a ``.env`` file next to the
+    config file.
 
     Priority (highest wins): YAML value > env var > ``.env`` file > default.
 
-    ``api_key`` is typically provided via the ``DSS_API_KEY`` environment
-    variable or ``.env`` file rather than YAML to avoid committing secrets.
+    Resolution is handled by :func:`~dss_provisioner.config.loader._resolve_provider`.
     """
-
-    model_config = SettingsConfigDict(env_prefix="DSS_")
 
     host: str | None = None
     api_key: str | None = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,18 @@
 """Shared fixtures for unit tests."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
+
+from dss_provisioner.config import load
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from dss_provisioner.config.schema import Config
 
 _DSS_ENV_VARS = ("DSS_HOST", "DSS_API_KEY", "DSS_PROJECT", "DSS_LOG")
 
@@ -10,3 +22,16 @@ def _clean_dss_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove DSS_* env vars so unit tests don't leak host config."""
     for var in _DSS_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def make_config(tmp_path: Path) -> Callable[..., Config]:
+    """Factory fixture: write YAML + optional .env, return loaded Config."""
+
+    def _make(yaml_str: str, *, dotenv: str | None = None) -> Config:
+        (tmp_path / "config.yaml").write_text(yaml_str)
+        if dotenv is not None:
+            (tmp_path / ".env").write_text(dotenv)
+        return load(tmp_path / "config.yaml")
+
+    return _make

--- a/tests/unit/test_config_api.py
+++ b/tests/unit/test_config_api.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dss_provisioner.config import _engine_from_config, load, plan
-from dss_provisioner.config.loader import ConfigError
+from dss_provisioner.config.loader import ConfigError, _resolve_provider
 from dss_provisioner.config.schema import Config, ProviderConfig
 
 _YAML = """\
@@ -54,72 +54,90 @@ class TestEngineFromConfig:
             _engine_from_config(config)
 
 
-class TestProviderConfigEnvResolution:
-    def test_api_key_from_env(self, monkeypatch) -> None:
-        monkeypatch.setenv("DSS_API_KEY", "env-secret")
-        p = ProviderConfig(project="X")
-        assert p.api_key == "env-secret"
+class TestResolveProvider:
+    """Unit tests for _resolve_provider priority chain (no YAML parsing)."""
 
-    def test_host_from_yaml_over_env(self, monkeypatch) -> None:
+    def test_yaml_value_wins(self) -> None:
+        result = _resolve_provider({"host": "https://from-yaml", "project": "P"}, Path())
+        assert result["host"] == "https://from-yaml"
+
+    def test_env_var_fallback(self, monkeypatch) -> None:
         monkeypatch.setenv("DSS_HOST", "https://from-env")
-        p = ProviderConfig(project="X", host="https://from-yaml")
-        assert p.host == "https://from-yaml"
+        result = _resolve_provider({"project": "P"}, Path())
+        assert result["host"] == "https://from-env"
 
-    def test_host_from_env_fallback(self, monkeypatch) -> None:
+    def test_yaml_value_over_env_var(self, monkeypatch) -> None:
         monkeypatch.setenv("DSS_HOST", "https://from-env")
-        p = ProviderConfig(project="X")
-        assert p.host == "https://from-env"
+        result = _resolve_provider({"host": "https://from-yaml", "project": "P"}, Path())
+        assert result["host"] == "https://from-yaml"
 
-    def test_api_key_from_env_file_kwarg(self, tmp_path) -> None:
-        env_file = tmp_path / ".env"
-        env_file.write_text("DSS_API_KEY=from-dotenv\n")
-        p = ProviderConfig(_env_file=env_file, project="X")  # type: ignore[call-arg]
-        assert p.api_key == "from-dotenv"
-
-    def test_env_var_overrides_env_file(self, tmp_path, monkeypatch) -> None:
-        env_file = tmp_path / ".env"
-        env_file.write_text("DSS_API_KEY=from-dotenv\n")
+    def test_yaml_null_falls_through_to_env_var(self, monkeypatch) -> None:
         monkeypatch.setenv("DSS_API_KEY", "from-env")
-        p = ProviderConfig(_env_file=env_file, project="X")  # type: ignore[call-arg]
-        assert p.api_key == "from-env"
+        result = _resolve_provider({"host": "https://h", "api_key": None, "project": "P"}, Path())
+        assert result["api_key"] == "from-env"
+
+    def test_missing_field_omitted(self) -> None:
+        result = _resolve_provider({"project": "P"}, Path())
+        assert "host" not in result
+        assert "api_key" not in result
+
+    def test_dotenv_file(self, tmp_path) -> None:
+        (tmp_path / ".env").write_text("DSS_API_KEY=from-dotenv\n")
+        result = _resolve_provider({"host": "https://h", "project": "P"}, tmp_path)
+        assert result["api_key"] == "from-dotenv"
+
+    def test_env_var_overrides_dotenv(self, tmp_path, monkeypatch) -> None:
+        (tmp_path / ".env").write_text("DSS_API_KEY=from-dotenv\n")
+        monkeypatch.setenv("DSS_API_KEY", "from-env")
+        result = _resolve_provider({"project": "P"}, tmp_path)
+        assert result["api_key"] == "from-env"
+
+    def test_yaml_null_falls_through_to_dotenv(self, tmp_path) -> None:
+        (tmp_path / ".env").write_text("DSS_API_KEY=from-dotenv\n")
+        result = _resolve_provider({"host": "https://h", "api_key": None, "project": "P"}, tmp_path)
+        assert result["api_key"] == "from-dotenv"
+
+    def test_dotenv_with_bom(self, tmp_path) -> None:
+        (tmp_path / ".env").write_bytes(b"\xef\xbb\xbfDSS_API_KEY=from-bom\n")
+        result = _resolve_provider({"host": "https://h", "project": "P"}, tmp_path)
+        assert result["api_key"] == "from-bom"
 
 
 class TestLoadFunction:
-    def test_load_returns_config(self, tmp_path) -> None:
-        f = tmp_path / "config.yaml"
-        f.write_text(_YAML)
-        config = load(f)
+    def test_load_returns_config(self, make_config) -> None:
+        config = make_config(_YAML)
         assert config.provider.project == "TEST"
         assert len(config.resources) == 1
 
-    def test_load_picks_up_dotenv_next_to_config(self, tmp_path) -> None:
-        (tmp_path / ".env").write_text("DSS_API_KEY=from-dotenv\n")
-        yaml = "provider:\n  host: https://h\n  project: P\n"
-        f = tmp_path / "config.yaml"
-        f.write_text(yaml)
-        config = load(f)
+    def test_dotenv_next_to_config(self, make_config) -> None:
+        config = make_config(
+            "provider:\n  host: https://h\n  project: P\n",
+            dotenv="DSS_API_KEY=from-dotenv\n",
+        )
         assert config.provider.api_key == "from-dotenv"
 
-    def test_load_dotenv_from_config_dir_not_cwd(self, tmp_path, monkeypatch) -> None:
+    def test_dotenv_from_config_dir_not_cwd(self, tmp_path, monkeypatch) -> None:
         subdir = tmp_path / "infra"
         subdir.mkdir()
         (subdir / ".env").write_text("DSS_API_KEY=from-subdir\n")
-        yaml = "provider:\n  host: https://h\n  project: P\n"
-        (subdir / "config.yaml").write_text(yaml)
+        (subdir / "config.yaml").write_text("provider:\n  host: https://h\n  project: P\n")
         monkeypatch.chdir(tmp_path)  # cwd has no .env
         config = load(subdir / "config.yaml")
         assert config.provider.api_key == "from-subdir"
+
+    def test_env_var_through_load(self, make_config, monkeypatch) -> None:
+        monkeypatch.setenv("DSS_API_KEY", "env-secret")
+        config = make_config("provider:\n  host: https://h\n  project: P\n")
+        assert config.provider.api_key == "env-secret"
 
 
 class TestPlanIntegration:
     @patch("dss_provisioner.config.resolve_code_files")
     @patch("dss_provisioner.engine.engine.DSSEngine.plan")
     def test_plan_calls_resolve_code_files(
-        self, mock_engine_plan: MagicMock, mock_resolve: MagicMock, tmp_path
+        self, mock_engine_plan: MagicMock, mock_resolve: MagicMock, make_config
     ) -> None:
-        f = tmp_path / "config.yaml"
-        f.write_text(_YAML)
-        config = load(f)
+        config = make_config(_YAML)
 
         mock_resolve.return_value = list(config.resources)
         mock_engine_plan.return_value = MagicMock()
@@ -131,11 +149,9 @@ class TestPlanIntegration:
     @patch("dss_provisioner.config.resolve_code_files")
     @patch("dss_provisioner.engine.engine.DSSEngine.plan")
     def test_plan_passes_destroy_and_refresh(
-        self, mock_engine_plan: MagicMock, mock_resolve: MagicMock, tmp_path
+        self, mock_engine_plan: MagicMock, mock_resolve: MagicMock, make_config
     ) -> None:
-        f = tmp_path / "c.yaml"
-        f.write_text(_YAML)
-        config = load(f)
+        config = make_config(_YAML)
 
         mock_resolve.return_value = list(config.resources)
         mock_engine_plan.return_value = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ dependencies = [
     { name = "dataiku-api-client" },
     { name = "filelock" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typer" },
@@ -374,7 +374,7 @@ requires-dist = [
     { name = "dataiku-api-client", specifier = ">=14.0" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "pydantic", specifier = ">=2.10" },
-    { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "typer", specifier = ">=0.9" },
@@ -966,20 +966,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `ProviderConfig(BaseSettings)` with `ProviderConfig(BaseModel)` and explicit `_resolve_provider()` function
- Priority chain is now readable code: YAML value > `os.environ` > `.env` file (via `python-dotenv`)
- Fixes YAML `null` values (`api_key:`) overriding `.env` fallbacks — the root cause of `.env` not working on Windows
- Handles BOM-encoded `.env` files (`utf-8-sig` encoding)
- Swap `pydantic-settings` dependency for `python-dotenv`
- Add `make_config` factory fixture and test `_resolve_provider` directly with dicts

Closes #83
Supersedes #84 (custom pydantic settings source — no longer needed)

## Test plan

- [x] 622 unit tests pass (net +5 from new env resolution tests)
- [x] `just format && just check` clean
- [x] Docs build
- [x] Verify `.env` loading on Windows target machine