### PR TITLE
Add params.mode to Snowflake and Oracle dataset resources

### DIFF
--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -237,6 +237,7 @@ datasets:
   - name: my_table
     type: snowflake
     connection: snowflake_prod
+    mode: table             # table (default) or query
     schema_name: RAW
     table: CUSTOMERS
     catalog: MY_DB          # optional

--- a/docs/guides/yaml-config.md
+++ b/docs/guides/yaml-config.md
@@ -295,6 +295,7 @@ Upload managed folders have no additional required fields.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `connection` | string | — | **Required.** Snowflake connection name |
+| `mode` | string | `table` | `table` or `query` |
 | `schema_name` | string | — | **Required.** Snowflake schema (non-empty) |
 | `table` | string | — | **Required.** Table name (non-empty) |
 | `catalog` | string | — | Snowflake database/catalog |
@@ -305,6 +306,7 @@ Upload managed folders have no additional required fields.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `connection` | string | — | **Required.** Oracle connection name |
+| `mode` | string | `table` | `table` or `query` |
 | `schema_name` | string | — | **Required.** Oracle schema (non-empty) |
 | `table` | string | — | **Required.** Table name (non-empty) |
 

--- a/src/dss_provisioner/resources/dataset.py
+++ b/src/dss_provisioner/resources/dataset.py
@@ -60,6 +60,7 @@ class SnowflakeDatasetResource(DatasetResource):
 
     type: Literal["Snowflake"] = "Snowflake"
     connection: Annotated[str, DSSParam("params.connection")]  # type: ignore[assignment]
+    mode: Annotated[Literal["table", "query"], DSSParam("params.mode")] = "table"
     schema_name: Annotated[str, DSSParam("params.schema")] = Field(min_length=1)
     table: Annotated[str, DSSParam("params.table")] = Field(min_length=1)
     catalog: Annotated[str | None, DSSParam("params.catalog")] = None
@@ -76,6 +77,7 @@ class OracleDatasetResource(DatasetResource):
 
     type: Literal["Oracle"] = "Oracle"
     connection: Annotated[str, DSSParam("params.connection")]  # type: ignore[assignment]
+    mode: Annotated[Literal["table", "query"], DSSParam("params.mode")] = "table"
     schema_name: Annotated[str, DSSParam("params.schema")] = Field(min_length=1)
     table: Annotated[str, DSSParam("params.table")] = Field(min_length=1)
 

--- a/tests/unit/test_dataset_handler.py
+++ b/tests/unit/test_dataset_handler.py
@@ -149,6 +149,7 @@ class TestCreateSnowflakeDataset:
             "Snowflake",
             params={
                 "connection": "sf_conn",
+                "mode": "table",
                 "schema": "PUBLIC",
                 "table": "users",
                 "writeMode": "OVERWRITE",
@@ -166,6 +167,7 @@ class TestCreateSnowflakeDataset:
             "Snowflake",
             params={
                 "connection": "sf_conn",
+                "mode": "table",
                 "schema": "PUBLIC",
                 "table": "users",
                 "writeMode": "OVERWRITE",
@@ -183,7 +185,12 @@ class TestCreateOracleDataset:
     ) -> None:
         raw = _make_raw(
             "Oracle",
-            params={"connection": "ora_conn", "schema": "HR", "table": "employees"},
+            params={
+                "connection": "ora_conn",
+                "mode": "table",
+                "schema": "HR",
+                "table": "employees",
+            },
         )
         mock_dataset.get_settings.return_value.get_raw.return_value = raw
 
@@ -197,6 +204,7 @@ class TestCreateOracleDataset:
             "Oracle",
             params={
                 "connection": "ora_conn",
+                "mode": "table",
                 "schema": "HR",
                 "table": "employees",
             },
@@ -643,6 +651,7 @@ class TestEngineIntegrationRoundtrip:
             "Snowflake",
             params={
                 "connection": "sf_conn",
+                "mode": "table",
                 "schema": "PUBLIC",
                 "table": "users",
                 "writeMode": "OVERWRITE",
@@ -676,7 +685,12 @@ class TestEngineIntegrationRoundtrip:
     def test_oracle_roundtrip(self, tmp_path: Path) -> None:
         raw = _make_raw(
             "Oracle",
-            params={"connection": "ora_conn", "schema": "HR", "table": "employees"},
+            params={
+                "connection": "ora_conn",
+                "mode": "table",
+                "schema": "HR",
+                "table": "employees",
+            },
         )
         engine, *_ = _setup_engine(tmp_path, raw)
 

--- a/tests/unit/test_dataset_resource.py
+++ b/tests/unit/test_dataset_resource.py
@@ -128,6 +128,7 @@ class TestSnowflakeDatasetResource:
             name="my_ds", connection="snowflake_conn", schema_name="PUBLIC", table="users"
         )
         assert ds.type == "Snowflake"
+        assert ds.mode == "table"
         assert ds.write_mode == "OVERWRITE"
         assert ds.catalog is None
 
@@ -166,6 +167,7 @@ class TestSnowflakeDatasetResource:
         dump = ds.model_dump(exclude_none=True, exclude={"address"})
         assert dump["type"] == "Snowflake"
         assert dump["connection"] == "snowflake_conn"
+        assert dump["mode"] == "table"
         assert dump["schema_name"] == "PUBLIC"
         assert dump["table"] == "users"
         assert dump["write_mode"] == "APPEND"
@@ -191,6 +193,7 @@ class TestSnowflakeDatasetResource:
         )
         assert ds.to_dss_params() == {
             "connection": "sf_conn",
+            "mode": "table",
             "schema": "PUBLIC",
             "table": "users",
             "catalog": "MY_CAT",
@@ -217,6 +220,7 @@ class TestOracleDatasetResource:
             name="my_ds", connection="oracle_conn", schema_name="HR", table="employees"
         )
         assert ds.type == "Oracle"
+        assert ds.mode == "table"
 
     def test_required_fields(self) -> None:
         with pytest.raises(ValidationError):
@@ -252,6 +256,7 @@ class TestOracleDatasetResource:
         dump = ds.model_dump(exclude_none=True, exclude={"address"})
         assert dump["type"] == "Oracle"
         assert dump["connection"] == "oracle_conn"
+        assert dump["mode"] == "table"
         assert dump["schema_name"] == "HR"
         assert dump["table"] == "employees"
 
@@ -261,6 +266,7 @@ class TestOracleDatasetResource:
         )
         assert ds.to_dss_params() == {
             "connection": "ora_conn",
+            "mode": "table",
             "schema": "HR",
             "table": "employees",
         }

--- a/tests/unit/test_markers.py
+++ b/tests/unit/test_markers.py
@@ -203,6 +203,7 @@ class TestSnowflakeToDssParams:
         )
         assert ds.to_dss_params() == {
             "connection": "sf_conn",
+            "mode": "table",
             "schema": "PUBLIC",
             "table": "users",
             "catalog": "MY_CAT",
@@ -217,6 +218,7 @@ class TestSnowflakeToDssParams:
         assert "catalog" not in params
         assert params == {
             "connection": "sf_conn",
+            "mode": "table",
             "schema": "PUBLIC",
             "table": "users",
             "writeMode": "OVERWRITE",
@@ -230,6 +232,7 @@ class TestOracleToDssParams:
         )
         assert ds.to_dss_params() == {
             "connection": "ora_conn",
+            "mode": "table",
             "schema": "HR",
             "table": "employees",
         }


### PR DESCRIPTION
## Summary

- Add `mode` field (`table` | `query`, default `table`) to `SnowflakeDatasetResource` and `OracleDatasetResource`
- DSS UI sets `params.mode` implicitly on dataset creation; the API does not — causing runtime failures without it

Closes #104

## Test plan

- [x] Unit tests updated: defaults, model dump, `to_dss_params`, handler create mocks, engine roundtrip
- [x] `just format`, `just check`, `just test` all pass (632 tests, 91% coverage)
- [x] Docs updated (`yaml-config.md` field tables, `resources.md` example)
- [x] Docs build verified