### PR TITLE
fix(foreign): replace computed_field with property for full_ref

### DIFF
--- a/src/dss_provisioner/resources/foreign.py
+++ b/src/dss_provisioner/resources/foreign.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import Field, computed_field
+from pydantic import Field
 
 from dss_provisioner.resources.base import Resource
 
@@ -19,7 +19,6 @@ class ForeignDatasetResource(Resource):
     source_project: str = Field(min_length=1)
     source_name: str = Field(min_length=1)
 
-    @computed_field
     @property
     def full_ref(self) -> str:
         return f"{self.source_project}.{self.source_name}"
@@ -35,7 +34,6 @@ class ForeignManagedFolderResource(Resource):
     source_project: str = Field(min_length=1)
     source_name: str = Field(min_length=1)
 
-    @computed_field
     @property
     def full_ref(self) -> str:
         return f"{self.source_project}.{self.source_name}"


### PR DESCRIPTION
## Summary

- Fixes #109 — `apply` fails on foreign resources with `extra inputs are not permitted` for `full_ref`
- Changes `full_ref` from `@computed_field` to a plain `@property` on `ForeignDatasetResource` and `ForeignManagedFolderResource`
- Removes unused `computed_field` import from `pydantic`

## Test plan

- [x] `just format` passes
- [x] `just check` passes
- [x] `just test` passes (661 tests, 100% coverage on `foreign.py`)
- [x] Verify `apply` succeeds for a config with `foreign_datasets`